### PR TITLE
is_array($result) should be !empty($result)

### DIFF
--- a/EventListener/LocaleDetectorListener.php
+++ b/EventListener/LocaleDetectorListener.php
@@ -128,7 +128,7 @@ class LocaleDetectorListener
                 }
             };
             $result = array_values(array_filter($providedLanguages, $map));
-            if (is_array($result)) {
+            if (!empty($result)) {
                 $preferredLanguage = $result[0];
             } else {
                 $preferredLanguage = $this->defaultLocale;


### PR DESCRIPTION
!empty($result) because when the user preference list and available list are not overlapping at all (e.g. "en,fr;" and "sp,kr;"), the $result is still going to be an array, although with no elements. empty() will take care of the NULL case as well. This change was unit tested pass.
