### PR TITLE
Using EventSubscriber instead of Event Listener, because the LocaleListe...

### DIFF
--- a/EventListener/LocaleUpdateListener.php
+++ b/EventListener/LocaleUpdateListener.php
@@ -15,17 +15,19 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 use Lunetics\LocaleBundle\Cookie\LocaleCookie;
 use Lunetics\LocaleBundle\Event\FilterLocaleSwitchEvent;
 use Lunetics\LocaleBundle\Session\LocaleSession;
+use Lunetics\LocaleBundle\LocaleBundleEvents;
 
 /**
  * Locale Update Listener
  *
  * @author Matthias Breddin <mb@lunetics.com>
  */
-class LocaleUpdateListener
+class LocaleUpdateListener implements EventSubscriberInterface
 {
     /**
      * @var string
@@ -96,6 +98,8 @@ class LocaleUpdateListener
      * Update Cookie Section
      *
      * @param bool $update If cookie should be updated
+     *
+     * @return bool
      */
     public function updateCookie($update)
     {
@@ -132,6 +136,8 @@ class LocaleUpdateListener
 
     /**
      * Update Session section
+     *
+     * @return bool
      */
     public function updateSession()
     {
@@ -157,5 +163,16 @@ class LocaleUpdateListener
     private function checkGuesser($guesser)
     {
         return in_array($guesser, $this->registeredGuessers);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            // must be registered after the Router to have access to the _locale and before the Symfony LocaleListener
+            LocaleBundleEvents::onLocaleChange => array('onLocaleChange')
+        );
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -35,13 +35,13 @@
         </service>
 
         <service id="lunetics_locale.locale_listener" class="%lunetics_locale.request_listener.class%">
-            <argument>%locale%</argument>
+            <argument>%kernel.default_locale%</argument>
             <argument type="service" id="lunetics_locale.guesser_manager" />
             <argument type="service" id="logger" />
             <call method="setEventDispatcher">
                 <argument type="service" id="event_dispatcher"/>
             </call>
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest"/>
+            <tag name="kernel.event_subscriber"/>
         </service>
 
         <service id="lunetics_locale.locale_update_listener" class="Lunetics\LocaleBundle\EventListener\LocaleUpdateListener" scope="request">
@@ -51,7 +51,7 @@
             <argument type="service" id="event_dispatcher" />
             <argument>%lunetics_locale.guessing_order%</argument>
             <argument type="service" id="logger" />
-            <tag name="kernel.event_listener" event="lunetics_locale.change" method="onLocaleChange" />
+            <tag name="kernel.event_subscriber" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
...ner must be called before the Symfony LocaleListener, which sets the locale in the router.
