### PR TITLE
LocaleUpdateListener no longer needs to be request scoped

### DIFF
--- a/Event/FilterLocaleSwitchEvent.php
+++ b/Event/FilterLocaleSwitchEvent.php
@@ -10,12 +10,18 @@
 namespace Lunetics\LocaleBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Filter for the LocaleSwitchEvent
  */
 class FilterLocaleSwitchEvent extends Event
 {
+    /**
+     * @var Request
+     */
+    protected $request;
+
     /**
      * @var string
      */
@@ -28,13 +34,24 @@ class FilterLocaleSwitchEvent extends Event
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($locale)
+    public function __construct(Request $request, $locale)
     {
         if (!is_string($locale) || null == $locale || '' == $locale) {
             throw new \InvalidArgumentException(sprintf('Wrong type, expected \'string\' got \'%s\'', $locale));
         }
 
+        $this->request = $request;
         $this->locale = $locale;
+    }
+
+    /**
+     * Returns the request
+     *
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
     }
 
     /**

--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -92,7 +92,7 @@ class LocaleListener implements EventSubscriberInterface
             $this->logEvent('Setting [ %s ] as defaultLocale for the Request', $locale);
             $request->setLocale($locale);
             if ($manager->getGuesser('session') || $manager->getGuesser('cookie')) {
-                $localeSwitchEvent = new FilterLocaleSwitchEvent($locale);
+                $localeSwitchEvent = new FilterLocaleSwitchEvent($request, $locale);
                 $this->dispatcher->dispatch(LocaleBundleEvents::onLocaleChange, $localeSwitchEvent);
             }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -44,10 +44,9 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
-        <service id="lunetics_locale.locale_update_listener" class="Lunetics\LocaleBundle\EventListener\LocaleUpdateListener" scope="request">
+        <service id="lunetics_locale.locale_update_listener" class="Lunetics\LocaleBundle\EventListener\LocaleUpdateListener">
             <argument type="service" id="lunetics_locale.locale_cookie" />
             <argument type="service" id="lunetics_locale.locale_session" />
-            <argument type="service" id="request" />
             <argument type="service" id="event_dispatcher" />
             <argument>%lunetics_locale.guessing_order%</argument>
             <argument type="service" id="logger" />

--- a/Tests/Event/FilterLocaleSwitchEventTest.php
+++ b/Tests/Event/FilterLocaleSwitchEventTest.php
@@ -11,13 +11,16 @@
 namespace Lunetics\LocaleBundle\Tests\Event;
 
 use Lunetics\LocaleBundle\Event\FilterLocaleSwitchEvent;
+use Symfony\Component\HttpFoundation\Request;
 
 class FilterLocaleSwitchEventTest extends \PHPUnit_Framework_TestCase
 {
     public function testFilterLocaleSwitchEvent()
     {
+        $request = Request::create('/');
         $locale = 'de';
-        $filter = new FilterLocaleSwitchEvent($locale);
+        $filter = new FilterLocaleSwitchEvent($request, $locale);
+        $this->assertEquals('/', $filter->getRequest()->getPathInfo());
         $this->assertEquals('de', $filter->getLocale());
     }
 
@@ -27,7 +30,7 @@ class FilterLocaleSwitchEventTest extends \PHPUnit_Framework_TestCase
     public function testThrowsInvalidTypeException($locale)
     {
         $this->setExpectedException('\InvalidArgumentException');
-        new FilterLocaleSwitchEvent($locale);
+        new FilterLocaleSwitchEvent(Request::create('/'), $locale);
     }
 
     public function invalidType()


### PR DESCRIPTION
instead the request instance is propagated via the event, fixes #43
