### PR TITLE
Fallback to primary before configured locale.

### DIFF
--- a/Validator/LocaleValidator.php
+++ b/Validator/LocaleValidator.php
@@ -80,8 +80,10 @@ class LocaleValidator extends ConstraintValidator
 
         if ($this->intlExtension) {
             $primary = SymfonyLocale::getPrimaryLanguage($locale);
-            $region = SymfonyLocale::getRegion($locale);
-            if ((null !== $region && strtolower($primary) != strtolower($region)) && !in_array($locale, SymfonyLocale::getLocales())) {
+            $region  = SymfonyLocale::getRegion($locale);
+            $locales = SymfonyLocale::getLocales();
+
+            if ((null !== $region && strtolower($primary) != strtolower($region)) && !in_array($locale, $locales) && !in_array($primary, $locales)) {
                 $this->context->addViolation($constraint->message, array('%string%' => $locale));
             }
         } else {


### PR DESCRIPTION
At this moment

`fr, fr_FR, fr_CH, fr_BE` .... is supported

In some applications, usage of locale can be:

`{lang}_{region}` and by this way, you can talk fr while being in united states: `fr_US`. IOS settings allow to do such things, so millions of IOS user can have some strange locales like that.

With this PR, If locale `fr_US` does not exists on ICU locales, it'll fallback first on primary then the configured locale.
