### PR TITLE
set the _locale attribute of the request to prevent symfony overrding it

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -84,6 +84,7 @@ class LocaleListener implements EventSubscriberInterface
         if ($locale) {
             $this->logEvent('Setting [ %s ] as locale for the (Sub-)Request', $locale);
             $request->setLocale($locale);
+            $request->attributes->add(array('_locale' => $locale));
 
             if (($event->getRequestType() === HttpKernelInterface::MASTER_REQUEST || $request->isXmlHttpRequest())
                 && ($manager->getGuesser('session') || $manager->getGuesser('cookie'))


### PR DESCRIPTION
This is another fix for issue #45 that works beside
https://github.com/lunetics/LocaleBundle/pull/59
