### PR TITLE
Fix to LocaleListener for Symfony 2.2.1

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -83,7 +83,7 @@ class LocaleListener implements EventSubscriberInterface
         $locale = $manager->runLocaleGuessing($request);
         if ($locale) {
             $this->logEvent('Setting [ %s ] as locale for the (Sub-)Request', $locale);
-            $request->setLocale($locale);
+            $request->attributes->set('_locale', $locale);
 
             if (($event->getRequestType() === HttpKernelInterface::MASTER_REQUEST || $request->isXmlHttpRequest())
                 && ($manager->getGuesser('session') || $manager->getGuesser('cookie'))


### PR DESCRIPTION
See issue #74. The Lunetics LocaleListener is designed to be invoked before the Symfony LocaleListener. The Symfony LocaleListener resets the request's locale to the value of the request's "_locale" attribute. Any locale set on the request will be ignored and overridden.
