### PR TITLE
Disable "Vary Accept-Language"-header

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('strict_mode')
                     ->defaultFalse()
                 ->end()
+                ->booleanNode('disable_vary_header')->defaultFalse()->end()
                 ->arrayNode('allowed_locales')
                     ->requiresAtLeastOneElement()
                     ->prototype('scalar')->end()

--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -50,6 +50,11 @@ class LocaleListener implements EventSubscriberInterface
     private $dispatcher;
 
     /**
+     * @var boolean
+     */
+    private $disableVaryHeader = false;
+
+    /**
      * Construct the guessermanager
      *
      * @param string               $defaultLocale  Framework default locale
@@ -103,7 +108,11 @@ class LocaleListener implements EventSubscriberInterface
      */
     public function onLocaleDetectedSetVaryHeader(FilterResponseEvent $event)
     {
-        return $event->getResponse()->setVary('Accept-Language', false);
+        $response = $event->getResponse();
+        if (!$this->disableVaryHeader) {
+            $response->setVary('Accept-Language', false);
+        }
+        return $response;
     }
     /**
      * DI Setter for the EventDispatcher
@@ -113,6 +122,13 @@ class LocaleListener implements EventSubscriberInterface
     public function setEventDispatcher(EventDispatcher $dispatcher)
     {
         $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * @param boolean $disableVaryHeader
+     */
+    public function setDisableVaryHeader ($disableVaryHeader) {
+        $this->disableVaryHeader = $disableVaryHeader;
     }
 
     /**

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -42,6 +42,9 @@
             <call method="setEventDispatcher">
                 <argument type="service" id="event_dispatcher"/>
             </call>
+            <call method="setDisableVaryHeader">
+                <argument>%lunetics_locale.disable_vary_header%</argument>
+            </call>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/Tests/EventListener/LocaleListenerTest.php
+++ b/Tests/EventListener/LocaleListenerTest.php
@@ -172,7 +172,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('fr', $request->getLocale());
     }
 
-    public function testOnLocacleDetectedSetVaryHeader()
+    public function testOnLocaleDetectedSetVaryHeader()
     {
         $listener = $this->getListener();
 
@@ -192,7 +192,23 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener->onLocaleDetectedSetVaryHeader($filterResponseEvent);
+    }
 
+    public function testOnLocaleDetectedDisabledVaryHeader () {
+        $listener = $this->getListener();
+        $listener->setDisableVaryHeader(true);
+
+        $response = $this->getMockResponse();
+        $response
+            ->expects($this->never())
+            ->method('setVary');
+        $filterResponseEvent = $this->getMockFilterResponseEvent();
+        $filterResponseEvent
+            ->expects($this->any())
+            ->method('getResponse')
+            ->will($this->returnValue($response));
+
+        $listener->onLocaleDetectedSetVaryHeader($filterResponseEvent);
     }
 
     public function testLogEvent()
@@ -243,7 +259,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new LocaleListener($locale, $manager, $logger);
         $listener->setEventDispatcher(new \Symfony\Component\EventDispatcher\EventDispatcher());
-        
+
         return $listener;
     }
 


### PR DESCRIPTION
It should be possible to disable the

```
Vary: Accept-Language
```

header, because it can disturb proxy-caches with websites, that uses separate URLs for different languages.
