### PR TITLE
The FilterLocaleSwitchEvent constructor needs the request object in documentation.

### DIFF
--- a/Resources/doc/index.markdown
+++ b/Resources/doc/index.markdown
@@ -114,7 +114,8 @@ For example, if you don't use route / query parameters for locales, you could bu
 
 ``` php
 $locale = $user->getLocale();
-$localeSwitchEvent = new FilterLocaleSwitchEvent($locale);
+$request = $this->getRequest();
+$localeSwitchEvent = new FilterLocaleSwitchEvent($request, $locale);
 $this->dispatcher->dispatch(LocaleBundleEvents::onLocaleChange, $localeSwitchEvent);
 ```
 ### Custom Form Types


### PR DESCRIPTION
Tha documentations is incorrect when using FilterLocaleSwitchEvent because it's missing the request object.
