### PR TITLE
Fix crash in LocaleChoiceList constructor

### DIFF
--- a/LocaleInformation/LocaleInformation.php
+++ b/LocaleInformation/LocaleInformation.php
@@ -73,7 +73,7 @@ class LocaleInformation
     {
         $preferredLocales = $this->filterAllowed($this->manager->getPreferredLocales());
 
-        return $preferredLocales;
+        return ($preferredLocales ? $preferredLocales : array());
     }
 
     /**


### PR DESCRIPTION
The constructor in LocaleChoiceList calls parent::__construct($this->localeChoices, $this->preferredChoices); the second option is expected to be an array.  getPreferredLocales() was returning false if none of the languages preferred by the browser match available locales.  Return an empty array instead of false in this case.
