### PR TITLE
Remove unused $request variable

### DIFF
--- a/LocaleGuesser/QueryLocaleGuesser.php
+++ b/LocaleGuesser/QueryLocaleGuesser.php
@@ -24,11 +24,6 @@ class QueryLocaleGuesser extends AbstractLocaleGuesser
     private $metaValidator;
 
     /**
-     * @var Request
-     */
-    private $request;
-
-    /**
      * Constructor
      *
      * @param MetaValidator $metaValidator       MetaValidator


### PR DESCRIPTION
The private $request variable is never used. Might as well remove it.
