### PR TITLE
Remove unused $intlExtension variable

### DIFF
--- a/LocaleGuesser/BrowserLocaleGuesser.php
+++ b/LocaleGuesser/BrowserLocaleGuesser.php
@@ -21,11 +21,6 @@ use Lunetics\LocaleBundle\Validator\MetaValidator;
 class BrowserLocaleGuesser extends AbstractLocaleGuesser
 {
     /**
-     * @var bool
-     */
-    private $intlExtension;
-
-    /**
      * @var MetaValidator
      */
     private $metaValidator;


### PR DESCRIPTION
The $intlExtension variable is unused in the class. Might as well remove it.
