### PR TITLE
MetaValidator compatible with symfony 2.5+

### DIFF
--- a/Validator/MetaValidator.php
+++ b/Validator/MetaValidator.php
@@ -9,7 +9,7 @@
  */
 namespace Lunetics\LocaleBundle\Validator;
 
-use Symfony\Component\Validator\Validator;
+use Symfony\Component\Validator\ValidatorInterface;
 use Lunetics\LocaleBundle\Validator\Locale;
 use Lunetics\LocaleBundle\Validator\LocaleAllowed;
 
@@ -26,9 +26,9 @@ class MetaValidator
     /**
      * Constructor
      *
-     * @param Validator $validator
+     * @param ValidatorInterface $validator
      */
-    public function __construct(Validator $validator)
+    public function __construct(ValidatorInterface $validator)
     {
         $this->validator = $validator;
     }


### PR DESCRIPTION
This changes will make LocaleBundle compatible with https://github.com/symfony/symfony/commit/274d4e619572cc88743cab9be37fe659de6d2ea2
