### PR TITLE
bump composer alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "target-dir": "Lunetics/LocaleBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2-dev"
+            "dev-master": "2.3-dev"
         }
     }
 }


### PR DESCRIPTION
as you tagged 2.3.0, we need to branch-alias master with 2.3-dev or people installing 2.2.\* will get the 2.3 version.
