### PR TITLE
Added XML support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
         $validStatuscodes = array(300, 301, 302, 303, 307);
 
         $rootNode
+            ->fixXmlConfig('allowed_locale')
             ->children()
                 ->scalarNode('strict_mode')
                     ->defaultFalse()
@@ -43,6 +44,10 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->arrayNode('guessing_order')
+                    ->beforeNormalization()
+                        ->ifString()
+                            ->then(function ($v) { return array($v); })
+                    ->end()
                     ->isRequired()
                     ->requiresAtLeastOneElement()
                 ->prototype('scalar')->end()


### PR DESCRIPTION
This PR adds XML support.

I would also recommend to add an XML namespace (this is returned in `Extension#getNamespace()`). It uses the default now, which is `http://example.org/schema/dic/lunetics_locale`.
