### PR TITLE
Set request _locale attribute in locale listener

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -101,6 +101,7 @@ class LocaleListener implements EventSubscriberInterface
 
             $this->logEvent('Setting [ %s ] as locale for the (Sub-)Request', $locale);
             $request->setLocale($locale);
+            $request->attributes->set('_locale', $locale);
 
             if (($event->getRequestType() === HttpKernelInterface::MASTER_REQUEST || $request->isXmlHttpRequest())
                 && ($manager->getGuesser('session') || $manager->getGuesser('cookie'))

--- a/Tests/EventListener/LocaleListenerTest.php
+++ b/Tests/EventListener/LocaleListenerTest.php
@@ -72,6 +72,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener->onKernelRequest($event);
         $this->assertEquals('de', $request->getLocale());
+        $this->assertEquals('de', $request->attributes->get('_locale'));
     }
 
     public function testCustomLocaleIsSetWhenQueryExist()
@@ -83,6 +84,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener->onKernelRequest($event);
         $this->assertEquals('de', $request->getLocale());
+        $this->assertEquals('de', $request->attributes->get('_locale'));
     }
 
     /**
@@ -98,6 +100,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $event = $this->getEvent($request);
         $listener->onKernelRequest($event);
         $this->assertEquals('es', $request->getLocale());
+        $this->assertEquals('es', $request->attributes->get('_locale'));
     }
 
     /**
@@ -113,6 +116,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $event = $this->getEvent($request);
         $listener->onKernelRequest($event);
         $this->assertEquals('fr_FR', $request->getLocale());
+        $this->assertEquals('fr_FR', $request->attributes->get('_locale'));
     }
 
     /**
@@ -128,6 +132,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $event = $this->getEvent($request);
         $listener->onKernelRequest($event);
         $this->assertEquals('fr_FR', $request->getLocale());
+        $this->assertEquals('fr_FR', $request->attributes->get('_locale'));
     }
 
     public function testThatGuesserIsNotCalledIfNotInGuessingOrder()


### PR DESCRIPTION
I'm working on a REST API, and I only use the `browser guesser` so the locale is determined by the `Accept-Language` header.

Asking for another locale than the default `en` one doesn't work, as symfony's `LocaleListener` is called just after, and use the request `_locale` attribute to set the request locale (see https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php#L91)

**Bundle LocaleListener** (sets the request locale from guessed locale)
echo $request->getLocale() // returns 'fr'
echo $request->attributes->get('_locale') // returns 'en'

**Symfony LocaleListener** (sets the  request locale from request `_locale` attribute)
echo $request->getLocale() // returns 'en'
echo $request->attributes->get('_locale') // returns 'en'

To fix this, this PR sets the request `_locale` attribute in locale listener.
