### PR TITLE
Initialize arrays in LocaleGuesserManager

### DIFF
--- a/LocaleGuesser/LocaleGuesserManager.php
+++ b/LocaleGuesser/LocaleGuesserManager.php
@@ -55,6 +55,8 @@ class LocaleGuesserManager
     public function __construct(array $guessingOrder, LoggerInterface $logger = null)
     {
         $this->guessingOrder = $guessingOrder;
+        $this->guessers = array();
+        $this->preferredLocales = array();
         $this->logger = $logger;
     }
 


### PR DESCRIPTION
This fixes an error when the listener is disabled for a given url where the `lunetics_locale` form type is used.
