### PR TITLE
update doc for 2.3 and improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The locale can be guessed from different parameters in your applications :
 
 [Read the Documentation for master](https://github.com/lunetics/LocaleBundle/blob/master/Resources/doc/index.markdown)
 
+[Read the Documentation for 2.2](https://github.com/lunetics/LocaleBundle/blob/2.2/Resources/doc/index.markdown)
+
 [Read the Documentation for 2.1](https://github.com/lunetics/LocaleBundle/blob/2.1/Resources/doc/index.markdown)
 
 ## License

--- a/Resources/doc/index.markdown
+++ b/Resources/doc/index.markdown
@@ -1,29 +1,32 @@
 # Installation
 
-### Add the package to your dependencies
-
-``` yaml
-"require": {
-    "lunetics/locale-bundle": "2.2.*",
-    ....
-},
-```
-
 ### Register the bundle in your kernel
 
 ``` php
 public function registerBundles()
-    {
-        $bundles = array(
-            // ...
-            new Lunetics\LocaleBundle\LuneticsLocaleBundle(),
-        );
+{
+    $bundles = array(
+        // ...
+        new Lunetics\LocaleBundle\LuneticsLocaleBundle(),
+    );
+```
+
+### Define a minimal configuration
+
+The full documentation options are explained below, but before you run composer
+you should place minimal configuration to avoid an error:
+
+```yaml
+lunetics_locale:
+  guessing_order:
+    - router
+    - browser
 ```
 
 ### Update your packages
 
 ```
-php composer.phar update lunetics/locale-bundle
+php composer.phar require lunetics/locale-bundle "2.3.*"
 ```
 
 # Configuration


### PR DESCRIPTION
stumbled over the fact that the doc talks about 2.2 while the current version is 2.3.1

also the setup instructions currently lead to an error from the symfony console that no guessing_order was defined. not sure why there is no default order...