### PR TITLE
keep query string when redirecting

### DIFF
--- a/Controller/LocaleController.php
+++ b/Controller/LocaleController.php
@@ -68,7 +68,14 @@ class LocaleController
         if ($useReferrer && $request->headers->has('referer')) {
             $response = new RedirectResponse($request->headers->get('referer'), $statusCode);
         } elseif ($this->router && $redirectToRoute) {
-            $response = new RedirectResponse($this->router->generate($redirectToRoute, array('_locale' => $_locale)), $statusCode);
+            $target = $this->router->generate($redirectToRoute, array('_locale' => $_locale));
+            if ($request->getQueryString()) {
+                if (!strpos($target, '?')) {
+                    $target .= '?';
+                }
+                $target .= $request->getQueryString();
+            }
+            $response = new RedirectResponse($target, $statusCode);
         } else {
             // TODO: this seems broken, as it will not handle if the site runs in a subdir
             // TODO: also it doesn't handle the locale at all and can therefore lead to an infinite redirect

--- a/Tests/Controller/LocaleControllerTest.php
+++ b/Tests/Controller/LocaleControllerTest.php
@@ -56,6 +56,16 @@ class LocaleControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://fallback_route.com/', $response->getTargetUrl());
     }
 
+    public function testControllerRedirectsToFallbackRouteWithParams()
+    {
+        $request = $this->getRequestWithBrowserPreferences('/?foo=bar');
+        $request->setLocale('de');
+
+        $localeController = $this->getLocaleController(true);
+        $response = $localeController->switchAction($request);
+        $this->assertEquals('http://fallback_route.com/?foo=bar', $response->getTargetUrl());
+    }
+
     public function testControllerNoMatchRedirect()
     {
         $request = $this->getRequestWithBrowserPreferences();


### PR DESCRIPTION
found out that we lose the query string. that string is important for one of our project, to allow to track google adwords. google is adding a query string that is later parsed in javascript, but lost during redirection.

if you think this could be a problem for some systems, i can make it configurable whether the query should be kept.