### PR TITLE
Test if route is not empty

### DIFF
--- a/Switcher/TargetInformationBuilder.php
+++ b/Switcher/TargetInformationBuilder.php
@@ -99,8 +99,10 @@ class TargetInformationBuilder
                         $switchRoute = $router->generate($targetRoute, $parameters);
                     } elseif ($this->useController) {
                         $switchRoute = $router->generate('lunetics_locale_switcher', array('_locale' => $locale));
-                    } else {
+                    } elseif ($route) {
                         $switchRoute = $router->generate($route, $parameters);
+                    } else {
+                        continue;
                     }
                 } catch (RouteNotFoundException $e) {
                     // skip routes for which we cannot generate a url for the given locale

--- a/Tests/Switcher/TargetInformationBuilderTest.php
+++ b/Tests/Switcher/TargetInformationBuilderTest.php
@@ -181,6 +181,21 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testGenerateNotCalledIfNoRoute()
+    {
+        $request = $this->getRequestWithBrowserPreferences();
+        $request->attributes->set('_route', null);
+        $router = $this->getRouter();
+
+        $targetInformationBuilder = new TargetInformationBuilder($request, $router, array('de', 'en', 'fr'), true, false);
+        $router
+            ->expects($this->never())
+            ->method('generate')
+        ;
+
+        $targetInformationBuilder->getTargetInformations();
+    }
+
     private function getRequestWithBrowserPreferences($route = "/")
     {
         $request = Request::create($route);


### PR DESCRIPTION
On 404 pages, the ``_route`` request attribute is not defined. In this case, it is not necessary to try to generate an url. Moreover, there is one (useless) line of debug log per locale : 

```
app.DEBUG: Router [...] was unable to generate route. Reason: 'Route '' not found': Unable to generate a URL for the named route "" as such route does not exist
```