### PR TITLE
Improve support of new validation api

### DIFF
--- a/Validator/MetaValidator.php
+++ b/Validator/MetaValidator.php
@@ -9,8 +9,8 @@
  */
 namespace Lunetics\LocaleBundle\Validator;
 
-use Symfony\Component\Validator\Validator\ValidatorInterface as ValidatorInterface2dot5;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 use Lunetics\LocaleBundle\Validator\Locale;
 use Lunetics\LocaleBundle\Validator\LocaleAllowed;
 
@@ -27,10 +27,14 @@ class MetaValidator
     /**
      * Constructor
      *
-     * @param ValidatorInterface $validator
+     * @param ValidatorInterface|LegacyValidatorInterface $validator
      */
-    public function __construct(ValidatorInterface $validator)
+    public function __construct($validator)
     {
+        if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
+            throw new \InvalidArgumentException('MetadataValidator accepts either the new or the old ValidatorInterface, '.get_class($validator).' was injected instead.');
+        }
+        
         $this->validator = $validator;
     }
 
@@ -43,10 +47,11 @@ class MetaValidator
      */
     public function isAllowed($locale)
     {
-        if ($this->validator instanceof ValidatorInterface2dot5) {
+        if ($this->validator instanceof ValidatorInterface) {
             $errorListLocale = $this->validator->validate($locale, new Locale);
             $errorListLocaleAllowed = $this->validator->validate($locale, new LocaleAllowed);
         } else {
+            // for Symfony <2.5 compatibility
             $errorListLocale = $this->validator->validateValue($locale, new Locale);
             $errorListLocaleAllowed = $this->validator->validateValue($locale, new LocaleAllowed);
         }


### PR DESCRIPTION
Not all validators extend both the legacy and new validator interface. The constructor should accept both.