### PR TITLE
Fix Duplicate header by subrequest

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -131,7 +131,7 @@ class LocaleListener implements EventSubscriberInterface
     public function onLocaleDetectedSetVaryHeader(FilterResponseEvent $event)
     {
         $response = $event->getResponse();
-        if (!$this->disableVaryHeader and $event->isMasterRequest()) {
+        if (!$this->disableVaryHeader && $event->isMasterRequest()) {
             $response->setVary('Accept-Language', false);
         }
         return $response;

--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -131,7 +131,7 @@ class LocaleListener implements EventSubscriberInterface
     public function onLocaleDetectedSetVaryHeader(FilterResponseEvent $event)
     {
         $response = $event->getResponse();
-        if (!$this->disableVaryHeader) {
+        if (!$this->disableVaryHeader and $event->isMasterRequest()) {
             $response->setVary('Accept-Language', false);
         }
         return $response;

--- a/Tests/EventListener/LocaleListenerTest.php
+++ b/Tests/EventListener/LocaleListenerTest.php
@@ -215,6 +215,11 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $filterResponseEvent = $this->getMockFilterResponseEvent();
         $filterResponseEvent
             ->expects($this->once())
+            ->method('isMasterRequest')
+            ->will($this->returnValue(true))
+        ;
+        $filterResponseEvent
+            ->expects($this->once())
             ->method('getResponse')
             ->will($this->returnValue($response))
         ;


### PR DESCRIPTION
sub request add HTTP header
Vary:Accept-Language
```
...
Cache-Control: no-cache
Vary: Accept-Language
Vary: Accept-Language
X-Debug-Token: 529924
...
```
That behavior looks like mistake.

Thats happen when Controller return subrequest.