### PR TITLE
Speed up Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,25 +10,27 @@ matrix:
   allow_failures:
     - php: hhvm
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 env:
   - SYMFONY_VERSION='2.8.*'
   - SYMFONY_VERSION='3.0.*'
 
-before_script:
+before_install:
+  - phpenv config-rm xdebug.ini || true
   - php -i | grep "ICU version"
   - composer self-update
   - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
-  - composer install --dev --prefer-source
 
-script: phpunit --coverage-text
+install: composer update --prefer-dist
+
+script: phpunit
 
 notifications:
   email:
     - willemsen.christophe@gmail.com
     - mb@lunetics.com
-
-sudo: false
-
-cache:
-  directories:
-    - $HOME/.composer/cache


### PR DESCRIPTION
 * Prefer dist installs, these can be cached (source installs can't)
 * Remove coverage details, so we can disable xDebug (makes both Composer and PHPunit significantly quicker)