### PR TITLE
use the new intl component instead of the deprecated locale component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.5.9",
         "symfony/framework-bundle": "^2.8|^3.0",
         "symfony/yaml": "^2.8|^3.0",
-        "symfony/locale": "^2.8|^3.0",
+        "symfony/intl": "^2.8|^3.0",
         "symfony/validator": "^2.8|^3.0",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
fix #186

i guess the dependency on locale made us install the intl component by dependency. but locale is deprecated and not installable with symfony 3.1