### PR TITLE
Update routing.yml

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -2,4 +2,4 @@ lunetics_locale_switcher:
     path: /changeLocale/{_locale}
     defaults:
         _controller: lunetics_locale.switcher_controller:switchAction
-        _locale: %locale%
+        _locale: '%locale%'


### PR DESCRIPTION
User Deprecated: Not quoting the scalar "%locale%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/lunetics/locale-bundle/Lunetics/LocaleBundle/Resources/config/routing.yml" on line 5.