### PR TITLE
Refactored the switcher extension to get all deps via injection

### DIFF
--- a/Resources/config/switcher.xml
+++ b/Resources/config/switcher.xml
@@ -18,7 +18,12 @@
         </service>
 
         <service id="lunetics_locale.twig.switcher" class="%lunetics_locale.twig.switcher.class%">
-            <argument type="service" id="service_container"/>
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="router"/>
+            <argument type="service" id="lunetics_locale.allowed_locales_provider"/>
+            <argument type="service" id="lunetics_locale.switcher_helper"/>
+            <argument>%lunetics_locale.switcher.use_controller%</argument>
+            <argument>%lunetics_locale.switcher.show_current_locale%</argument>
             <tag name="twig.extension"/>
         </service>
 

--- a/Templating/Helper/LocaleSwitchHelper.php
+++ b/Templating/Helper/LocaleSwitchHelper.php
@@ -40,7 +40,6 @@ class LocaleSwitchHelper extends Helper
     }
 
     /**
-     *
      * @param array $viewParams
      */
     public function renderSwitch(array $viewParams = array(), $template = null)

--- a/Tests/EventListener/LocaleListenerTest.php
+++ b/Tests/EventListener/LocaleListenerTest.php
@@ -306,7 +306,11 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
     private function getEvent(Request $request)
     {
-        return new GetResponseEvent($this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'), $request, HttpKernelInterface::MASTER_REQUEST);
+        return new GetResponseEvent(
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
     }
 
     private function getListener($locale = 'en', $manager = null, $logger = null, $matcher = null)
@@ -411,14 +415,9 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         return $request;
     }
 
-    private function getMockRequest()
-    {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request');
-    }
-
     private function getMockResponse()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Response');
+        return $this->createMock('Symfony\Component\HttpFoundation\Response');
     }
 
     private function getMockFilterResponseEvent()
@@ -432,6 +431,6 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
     private function getMockLogger()
     {
-        return $this->getMock('Psr\Log\LoggerInterface');
+        return $this->createMock('Psr\Log\LoggerInterface');
     }
 }

--- a/Tests/EventListener/LocaleUpdateTest.php
+++ b/Tests/EventListener/LocaleUpdateTest.php
@@ -179,7 +179,12 @@ class LocaleUpdateTest extends \PHPUnit_Framework_TestCase
 
     private function getEvent(Request $request)
     {
-        return new FilterResponseEvent($this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'), $request, HttpKernelInterface::MASTER_REQUEST, new Response);
+        return new FilterResponseEvent(
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response
+        );
     }
 
 
@@ -199,6 +204,6 @@ class LocaleUpdateTest extends \PHPUnit_Framework_TestCase
 
     private function getMockLogger()
     {
-        return $this->getMock('Psr\Log\LoggerInterface');
+        return $this->createMock('Psr\Log\LoggerInterface');
     }
 }

--- a/Tests/Form/Extension/Type/LocaleTypeTest.php
+++ b/Tests/Form/Extension/Type/LocaleTypeTest.php
@@ -55,6 +55,6 @@ class LocaleTypeTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockOptionsResolverInterface()
     {
-        return $this->getMock('Symfony\Component\OptionsResolver\OptionsResolver');
+        return $this->createMock('Symfony\Component\OptionsResolver\OptionsResolver');
     }
 }

--- a/Tests/LocaleGuesser/DomainLocaleGuesserTest.php
+++ b/Tests/LocaleGuesser/DomainLocaleGuesserTest.php
@@ -83,6 +83,6 @@ class DomainLocaleGuesserTest extends \PHPUnit_Framework_TestCase
 
     private function getMockRequest()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+        return $this->createMock('Symfony\Component\HttpFoundation\Request');
     }
-} 
+}

--- a/Tests/LocaleGuesser/LocaleGuesserManagerTest.php
+++ b/Tests/LocaleGuesser/LocaleGuesserManagerTest.php
@@ -21,7 +21,7 @@ class LocaleGuesserManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function testLocaleGuessingInvalidGuesser()
     {
-        $this->setExpectedException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
         $guesserManager = new LocaleGuesserManager(array(0 => 'foo'));
         $guesserManager->addGuesser($this->getGuesserMock(), 'bar');
         $guesserManager->runLocaleGuessing($this->getRequestWithoutLocaleQuery());
@@ -137,7 +137,9 @@ class LocaleGuesserManagerTest extends \PHPUnit_Framework_TestCase
      */
     private function getGuesserMock()
     {
-        $mock = $this->getMockBuilder('Lunetics\LocaleBundle\LocaleGuesser\LocaleGuesserInterface')->disableOriginalConstructor()->getMock();
+        $mock = $this->getMockBuilder('Lunetics\LocaleBundle\LocaleGuesser\LocaleGuesserInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         return $mock;
     }
@@ -147,14 +149,16 @@ class LocaleGuesserManagerTest extends \PHPUnit_Framework_TestCase
      */
     private function getMetaValidatorMock()
     {
-        $mock = $this->getMockBuilder('\Lunetics\LocaleBundle\Validator\MetaValidator')->disableOriginalConstructor()->getMock();
+        $mock = $this->getMockBuilder('\Lunetics\LocaleBundle\Validator\MetaValidator')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         return $mock;
     }
 
     private function getMockLogger()
     {
-        return $this->getMock('Psr\Log\LoggerInterface');
+        return $this->createMock('Psr\Log\LoggerInterface');
     }
 
 }

--- a/Tests/LocaleGuesser/SubdomainLocaleGuesserTest.php
+++ b/Tests/LocaleGuesser/SubdomainLocaleGuesserTest.php
@@ -59,7 +59,7 @@ class SubdomainLocaleGuesserTest extends \PHPUnit_Framework_TestCase
             array(false, 'de-DE.domain', false, '_'),
         );
     }
-    
+
     private function getMockMetaValidator()
     {
         return $this
@@ -71,6 +71,6 @@ class SubdomainLocaleGuesserTest extends \PHPUnit_Framework_TestCase
 
     private function getMockRequest()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+        return $this->createMock('Symfony\Component\HttpFoundation\Request');
     }
 }

--- a/Tests/LocaleGuesser/TopleveldomainLocaleGuesserTest.php
+++ b/Tests/LocaleGuesser/TopleveldomainLocaleGuesserTest.php
@@ -84,6 +84,6 @@ class TopleveldomainLocaleGuesserTest extends \PHPUnit_Framework_TestCase
 
     private function getMockRequest()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+        return $this->createMock('Symfony\Component\HttpFoundation\Request');
     }
-} 
+}

--- a/Tests/LuneticsLocaleBundleTest.php
+++ b/Tests/LuneticsLocaleBundleTest.php
@@ -40,6 +40,6 @@ class LuneticsLocaleBundleTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockContainer()
     {
-        return $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        return $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
     }
 }

--- a/Tests/Session/LocaleSessionTest.php
+++ b/Tests/Session/LocaleSessionTest.php
@@ -74,6 +74,6 @@ class LocaleSessionTest extends \PHPUnit_Framework_TestCase
 
     public function getMockSession()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Session\Session');
+        return $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
     }
 }

--- a/Tests/Templating/Helper/LocaleSwitchHelperTest.php
+++ b/Tests/Templating/Helper/LocaleSwitchHelperTest.php
@@ -44,6 +44,6 @@ class LocaleSwitchHelperTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockEngineInterface()
     {
-        return $this->getMock('Symfony\Component\Templating\EngineInterface');
+        return $this->createMock('Symfony\Component\Templating\EngineInterface');
     }
 }

--- a/Tests/Validator/LocaleAllowedValidatorTest.php
+++ b/Tests/Validator/LocaleAllowedValidatorTest.php
@@ -123,9 +123,9 @@ class LocaleAllowedValidatorTest extends BaseMetaValidator
         $validator->validate(null, $this->getMockConstraint());
         $validator->validate('', $this->getMockConstraint());
     }
-    
+
     protected function getMockConstraint()
     {
-        return $this->getMock('Symfony\Component\Validator\Constraint');
+        return $this->createMock('Symfony\Component\Validator\Constraint');
     }
 }

--- a/Tests/Validator/LocaleValidatorTest.php
+++ b/Tests/Validator/LocaleValidatorTest.php
@@ -134,6 +134,6 @@ class LocaleValidatorTest extends BaseMetaValidator
 
     protected function getMockConstraint()
     {
-        return $this->getMock('Symfony\Component\Validator\Constraint');
+        return $this->createMock('Symfony\Component\Validator\Constraint');
     }
 }


### PR DESCRIPTION
- Fixes #200 
- Also fixed some deprecation issues with phpunit

The main problem that remains is that I don't see any real functional test to check the integration with symfony. 
So basically apart from the unit test nothing else broke from the change. Configuration defaults are untested. I can remove an argument from the service definitions and all tests still pass. So that should probably be a new issue.