### PR TITLE
do not use container directly

### DIFF
--- a/LocaleInformation/AllowedLocalesProvider.php
+++ b/LocaleInformation/AllowedLocalesProvider.php
@@ -7,8 +7,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that is distributed with this source code.
  */
-namespace Lunetics\LocaleBundle\LocaleInformation;
 
+namespace Lunetics\LocaleBundle\LocaleInformation;
 
 class AllowedLocalesProvider
 {

--- a/Resources/config/switcher.xml
+++ b/Resources/config/switcher.xml
@@ -18,7 +18,8 @@
         </service>
 
         <service id="lunetics_locale.twig.switcher" class="%lunetics_locale.twig.switcher.class%">
-            <argument type="service" id="service_container"/>
+            <argument type="service" id="lunetics_locale.switcher.target_information_builder"/>
+            <argument type="service" id="lunetics_locale.switcher_helper"/>
             <tag name="twig.extension"/>
         </service>
 
@@ -30,5 +31,12 @@
             <argument>%lunetics_locale.switcher.redirect_statuscode%</argument>
         </service>
 
+        <service id="lunetics_locale.switcher.target_information_builder" class="Lunetics\LocaleBundle\Switcher\TargetInformationBuilder">
+            <argument type="service" id="request_stack" />
+            <argument type="service" id="router.default"/>
+            <argument type="service" id="lunetics_locale.allowed_locales_provider"/>
+            <argument>'%lunetics_locale.switcher.show_current_locale%'</argument>
+            <argument>'%lunetics_locale.switcher.use_controlle%'</argument>
+        </service>
     </services>
 </container>

--- a/Switcher/TargetInformationBuilder.php
+++ b/Switcher/TargetInformationBuilder.php
@@ -26,11 +26,26 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class TargetInformationBuilder
 {
-    private $request;
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+    /**
+     * @var RouterInterface
+     */
     private $router;
+    /**
+     * @var bool
+     */
     private $showCurrentLocale;
+    /**
+     * @var bool
+     */
     private $useController;
-    private $allowedLocales;
+    /**
+     * @var AllowedLocalesProvider
+     */
+    private $allowedLocalesProvider;
 
     /**
      * @param RequestStack $requestStack Request
@@ -46,9 +61,9 @@ class TargetInformationBuilder
         $showCurrentLocale = false,
         $useController = false
     ) {
-        $this->request = $requestStack->getCurrentRequest();
+        $this->requestStack = $requestStack;
         $this->router = $router;
-        $this->allowedLocales = $allowedLocalesProvider->getAllowedLocales();
+        $this->allowedLocalesProvider = $allowedLocalesProvider;
         $this->showCurrentLocale = $showCurrentLocale;
         $this->useController = $useController;
     }
@@ -75,7 +90,7 @@ class TargetInformationBuilder
      */
     public function getTargetInformations($targetRoute = null, $parameters = [])
     {
-        $request = $this->request;
+        $request = $this->requestStack->getCurrentRequest();
         $router = $this->router;
         $route = $request->attributes->get('_route');
 
@@ -94,8 +109,7 @@ class TargetInformationBuilder
 
         $parameters = array_merge((array) $request->attributes->get('_route_params'), $request->query->all(), (array) $parameters);
 
-        $targetLocales = $this->allowedLocales;
-        foreach ($targetLocales as $locale) {
+        foreach ($this->allowedLocalesProvider->getAllowedLocales() as $locale) {
             $strpos = 0 === strpos($request->getLocale(), $locale);
             if ($this->showCurrentLocale && $strpos || !$strpos) {
                 $targetLocaleTargetLang = Intl::getLanguageBundle()->getLanguageName($locale, null, $locale);

--- a/Tests/EventListener/LocaleListenerTest.php
+++ b/Tests/EventListener/LocaleListenerTest.php
@@ -10,9 +10,14 @@
 
 namespace Lunetics\LocaleBundle\Tests\EventListener;
 
+use Lunetics\LocaleBundle\LocaleGuesser\LocaleGuesserInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
@@ -147,7 +152,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testDispatcherIsFired()
     {
-        $dispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
+        $dispatcherMock = $this->createMock(EventDispatcher::class);
         $dispatcherMock->expects($this->once())
                         ->method('dispatch')
                         ->with($this->equalTo(LocaleBundleEvents::onLocaleChange), $this->isInstanceOf('Lunetics\LocaleBundle\Event\FilterLocaleSwitchEvent'));
@@ -162,7 +167,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testDispatcherIsNotFired()
     {
-        $dispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')->disableOriginalConstructor()->getMock();
+        $dispatcherMock = $this->createMock(EventDispatcher::class);
         $dispatcherMock->expects($this->never())
                 ->method('dispatch');
 
@@ -306,7 +311,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
     private function getEvent(Request $request)
     {
-        return new GetResponseEvent($this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'), $request, HttpKernelInterface::MASTER_REQUEST);
+        return new GetResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST);
     }
 
     private function getListener($locale = 'en', $manager = null, $logger = null, $matcher = null)
@@ -316,7 +321,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         }
 
         $listener = new LocaleListener($locale, $manager, $matcher, $logger);
-        $listener->setEventDispatcher(new \Symfony\Component\EventDispatcher\EventDispatcher());
+        $listener->setEventDispatcher(new EventDispatcher());
 
         return $listener;
     }
@@ -352,11 +357,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
     private function getMockGuesserManager()
     {
-        return $this
-            ->getMockBuilder('Lunetics\LocaleBundle\LocaleGuesser\LocaleGuesserManager')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
+        return $this->createMock(LocaleGuesserManager::class);
     }
 
     /**
@@ -364,9 +365,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
      */
     private function getMockGuesser()
     {
-        $mock = $this->getMockBuilder('Lunetics\LocaleBundle\LocaleGuesser\LocaleGuesserInterface')->disableOriginalConstructor()->getMock();
-
-        return $mock;
+        return $this->createMock(LocaleGuesserInterface::class);
     }
 
     /**
@@ -374,9 +373,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
      */
     private function getMetaValidatorMock()
     {
-        $mock = $this->getMockBuilder('\Lunetics\LocaleBundle\Validator\MetaValidator')->disableOriginalConstructor()->getMock();
-
-        return $mock;
+        return $this->createMock(MetaValidator::class);
     }
 
     private function getRequestWithRouterParam($routerLocale = 'es')
@@ -413,25 +410,21 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
     private function getMockRequest()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+        return $this->createMock(Request::class);
     }
 
     private function getMockResponse()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Response');
+        return $this->createMock(Response::class);
     }
 
     private function getMockFilterResponseEvent()
     {
-        return $this
-            ->getMockBuilder('Symfony\Component\HttpKernel\Event\FilterResponseEvent')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
+        return $this->createMock(FilterResponseEvent::class);
     }
 
     private function getMockLogger()
     {
-        return $this->getMock('Psr\Log\LoggerInterface');
+        return $this->createMock(LoggerInterface::class);
     }
 }

--- a/Tests/EventListener/LocaleUpdateTest.php
+++ b/Tests/EventListener/LocaleUpdateTest.php
@@ -11,6 +11,7 @@
 namespace Lunetics\LocaleBundle\Tests\EventListener;
 
 use Lunetics\LocaleBundle\LocaleBundleEvents;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -179,7 +180,7 @@ class LocaleUpdateTest extends \PHPUnit_Framework_TestCase
 
     private function getEvent(Request $request)
     {
-        return new FilterResponseEvent($this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'), $request, HttpKernelInterface::MASTER_REQUEST, new Response);
+        return new FilterResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST, new Response);
     }
 
 
@@ -199,6 +200,6 @@ class LocaleUpdateTest extends \PHPUnit_Framework_TestCase
 
     private function getMockLogger()
     {
-        return $this->getMock('Psr\Log\LoggerInterface');
+        return $this->createMock(LoggerInterface::class);
     }
 }

--- a/Tests/Form/Extension/Type/LocaleTypeTest.php
+++ b/Tests/Form/Extension/Type/LocaleTypeTest.php
@@ -9,7 +9,9 @@
  */
 namespace Lunetics\LocaleBundle\Tests\Form\Extension\Type;
 
+use Lunetics\LocaleBundle\Form\Extension\ChoiceList\LocaleChoiceList;
 use Lunetics\LocaleBundle\Form\Extension\Type\LocaleType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Kevin Archer <ka@kevinarcher.ca>
@@ -46,15 +48,11 @@ class LocaleTypeTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockLocaleChoiceList()
     {
-        return $this
-            ->getMockBuilder('Lunetics\LocaleBundle\Form\Extension\ChoiceList\LocaleChoiceList')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
+        return $this->createMock(LocaleChoiceList::class);
     }
 
     protected function getMockOptionsResolverInterface()
     {
-        return $this->getMock('Symfony\Component\OptionsResolver\OptionsResolver');
+        return $this->createMock(OptionsResolver::class);
     }
 }

--- a/Tests/LocaleGuesser/DomainLocaleGuesserTest.php
+++ b/Tests/LocaleGuesser/DomainLocaleGuesserTest.php
@@ -10,6 +10,9 @@
 namespace Lunetics\LocaleBundle\Tests\LocaleGuesser;
 
 use Lunetics\LocaleBundle\LocaleGuesser\DomainLocaleGuesser;
+use Lunetics\LocaleBundle\LocaleInformation\DomainLocaleMap;
+use Lunetics\LocaleBundle\Validator\MetaValidator;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Jachim Coudenys <jachimcoudenys@gmail.com>
@@ -65,24 +68,21 @@ class DomainLocaleGuesserTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @return mixed
+     */
     private function getMockDomainLocaleMap()
     {
-        return $this
-            ->getMockBuilder('\Lunetics\LocaleBundle\LocaleInformation\DomainLocaleMap')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(DomainLocaleMap::class);
     }
 
     private function getMockMetaValidator()
     {
-        return $this
-            ->getMockBuilder('\Lunetics\LocaleBundle\Validator\MetaValidator')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(MetaValidator::class);
     }
 
     private function getMockRequest()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+        return $this->createMock(Request::class);
     }
-} 
+}

--- a/Tests/LocaleGuesser/LocaleGuesserManagerTest.php
+++ b/Tests/LocaleGuesser/LocaleGuesserManagerTest.php
@@ -9,6 +9,7 @@
  */
 namespace Lunetics\LocaleBundle\Tests\LocaleGuesser;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 use Lunetics\LocaleBundle\LocaleGuesser\RouterLocaleGuesser;
@@ -137,7 +138,7 @@ class LocaleGuesserManagerTest extends \PHPUnit_Framework_TestCase
      */
     private function getGuesserMock()
     {
-        $mock = $this->getMockBuilder('Lunetics\LocaleBundle\LocaleGuesser\LocaleGuesserInterface')->disableOriginalConstructor()->getMock();
+        $mock = $this->createMock(LocaleGuesserInterface::class);
 
         return $mock;
     }
@@ -147,14 +148,14 @@ class LocaleGuesserManagerTest extends \PHPUnit_Framework_TestCase
      */
     private function getMetaValidatorMock()
     {
-        $mock = $this->getMockBuilder('\Lunetics\LocaleBundle\Validator\MetaValidator')->disableOriginalConstructor()->getMock();
+        $mock = $this->createMock(MetaValidator::class);
 
         return $mock;
     }
 
     private function getMockLogger()
     {
-        return $this->getMock('Psr\Log\LoggerInterface');
+        return $this->createMock(LoggerInterface::class);
     }
 
 }

--- a/Tests/LocaleGuesser/SubdomainLocaleGuesserTest.php
+++ b/Tests/LocaleGuesser/SubdomainLocaleGuesserTest.php
@@ -7,9 +7,12 @@
  * For the full copyright and license information, please view the LICENSE
  * file that is distributed with this source code.
  */
+
 namespace Lunetics\LocaleBundle\Tests\LocaleGuesser;
 
 use Lunetics\LocaleBundle\LocaleGuesser\SubdomainLocaleGuesser;
+use Lunetics\LocaleBundle\Validator\MetaValidator;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Kevin Archer <ka@kevinarcher.ca>
@@ -31,16 +34,14 @@ class SubdomainLocaleGuesserTest extends \PHPUnit_Framework_TestCase
             $metaValidator
                 ->expects($this->once())
                 ->method('isAllowed')
-                ->will($this->returnValue($allowed))
-            ;
+                ->will($this->returnValue($allowed));
         }
 
         $request = $this->getMockRequest();
         $request
             ->expects($this->once())
             ->method('getHost')
-            ->will($this->returnValue($host))
-        ;
+            ->will($this->returnValue($host));
 
         $guesser = new SubdomainLocaleGuesser($metaValidator, $seperator);
 
@@ -49,28 +50,24 @@ class SubdomainLocaleGuesserTest extends \PHPUnit_Framework_TestCase
 
     public function dataDomains()
     {
-        return array(
-            array(true,  'en.domain',    true,  null),
-            array(false, 'fr.domain',    false, null),
-            array(false, 'domain',       null,  null),
-            array(false, 'www.domain',   false, null),
-            array(true,  'en-ca.domain', true,  '-'),
-            array(true,  'fr_ca.domain', true,  '_'),
-            array(false, 'de-DE.domain', false, '_'),
-        );
+        return [
+            [true, 'en.domain', true, null],
+            [false, 'fr.domain', false, null],
+            [false, 'domain', null, null],
+            [false, 'www.domain', false, null],
+            [true, 'en-ca.domain', true, '-'],
+            [true, 'fr_ca.domain', true, '_'],
+            [false, 'de-DE.domain', false, '_'],
+        ];
     }
-    
+
     private function getMockMetaValidator()
     {
-        return $this
-            ->getMockBuilder('\Lunetics\LocaleBundle\Validator\MetaValidator')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
+        return $this->createMock(MetaValidator::class);
     }
 
     private function getMockRequest()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+        return $this->createMock(Request::class);
     }
 }

--- a/Tests/LocaleGuesser/TopleveldomainLocaleGuesserTest.php
+++ b/Tests/LocaleGuesser/TopleveldomainLocaleGuesserTest.php
@@ -11,6 +11,8 @@ namespace Lunetics\LocaleBundle\Tests\LocaleGuesser;
 
 use Lunetics\LocaleBundle\LocaleGuesser\TopleveldomainLocaleGuesser;
 use Lunetics\LocaleBundle\LocaleInformation\TopleveldomainLocaleMap;
+use Lunetics\LocaleBundle\Validator\MetaValidator;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Ivo Bathke <ivo.bathke@gmail.com>
@@ -68,22 +70,16 @@ class TopleveldomainLocaleGuesserTest extends \PHPUnit_Framework_TestCase
 
     private function getMockTopleveldomainLocaleMap()
     {
-        return $this
-            ->getMockBuilder('\Lunetics\LocaleBundle\LocaleInformation\TopleveldomainLocaleMap')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(TopleveldomainLocaleMap::class);
     }
 
     private function getMockMetaValidator()
     {
-        return $this
-            ->getMockBuilder('\Lunetics\LocaleBundle\Validator\MetaValidator')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(MetaValidator::class);
     }
 
     private function getMockRequest()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+        return $this->createMock(Request::class);
     }
-} 
+}

--- a/Tests/LuneticsLocaleBundleTest.php
+++ b/Tests/LuneticsLocaleBundleTest.php
@@ -12,6 +12,7 @@ namespace Lunetics\LocaleBundle\Tests;
 use Lunetics\LocaleBundle\DependencyInjection\Compiler\GuesserCompilerPass;
 use Lunetics\LocaleBundle\DependencyInjection\Compiler\RouterResourcePass;
 use Lunetics\LocaleBundle\LuneticsLocaleBundle;
+use Psr\Container\ContainerInterface;
 
 /**
  * @author Kevin Archer <ka@kevinarcher.ca>
@@ -40,6 +41,6 @@ class LuneticsLocaleBundleTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockContainer()
     {
-        return $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        return $this->createMock(ContainerInterface::class);
     }
 }

--- a/Tests/LuneticsLocaleBundleTest.php
+++ b/Tests/LuneticsLocaleBundleTest.php
@@ -12,7 +12,7 @@ namespace Lunetics\LocaleBundle\Tests;
 use Lunetics\LocaleBundle\DependencyInjection\Compiler\GuesserCompilerPass;
 use Lunetics\LocaleBundle\DependencyInjection\Compiler\RouterResourcePass;
 use Lunetics\LocaleBundle\LuneticsLocaleBundle;
-use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Kevin Archer <ka@kevinarcher.ca>
@@ -41,6 +41,6 @@ class LuneticsLocaleBundleTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockContainer()
     {
-        return $this->createMock(ContainerInterface::class);
+        return $this->createMock(ContainerBuilder::class);
     }
 }

--- a/Tests/Session/LocaleSessionTest.php
+++ b/Tests/Session/LocaleSessionTest.php
@@ -10,6 +10,7 @@
 namespace Lunetics\LocaleBundle\Tests\LocaleInformation;
 
 use Lunetics\LocaleBundle\Session\LocaleSession;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * @author Kevin Archer <ka@kevinarcher.ca>
@@ -74,6 +75,6 @@ class LocaleSessionTest extends \PHPUnit_Framework_TestCase
 
     public function getMockSession()
     {
-        return $this->getMock('Symfony\Component\HttpFoundation\Session\Session');
+        return $this->createMock(Session::class);
     }
 }

--- a/Tests/Switcher/TargetInformationBuilderTest.php
+++ b/Tests/Switcher/TargetInformationBuilderTest.php
@@ -5,6 +5,7 @@ namespace Lunetics\LocaleBundle\Tests\Validator;
 use Lunetics\LocaleBundle\Switcher\TargetInformationBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 
 class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
@@ -27,7 +28,7 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testProvideRouteInInformationBuilder($route, $locale, $allowedLocales)
     {
-        $request = $this->getRequestWithBrowserPreferences($route);
+        $request = $this->getRequestWithBrowserPreferences($route, $locale);
         $request->setLocale($locale);
         $request->attributes->set('_route', $route);
         $router = $this->getRouter();
@@ -122,8 +123,7 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testInformationBuilder($route, $locale, $allowedLocales)
     {
-        $request = $this->getRequestWithBrowserPreferences($route);
-        $request->setLocale($locale);
+        $request = $this->getRequestWithBrowserPreferences($route, $locale);
         $request->attributes->set('_route', $route);
         $router = $this->getRouter();
 
@@ -196,12 +196,15 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
         $targetInformationBuilder->getTargetInformations();
     }
 
-    private function getRequestWithBrowserPreferences($route = "/")
+    private function getRequestWithBrowserPreferences($route = "/", $locale)
     {
         $request = Request::create($route);
+        $requestStack = new RequestStack();
+        $request->setLocale($locale);
         $request->headers->set('Accept-language', 'fr-FR,fr;q=0.1,en-US;q=0.6,en;q=0.4');
+        $requestStack->push($request);
 
-        return $request;
+        return $requestStack;
     }
 
     private function getRouter()

--- a/Tests/Switcher/TargetInformationBuilderTest.php
+++ b/Tests/Switcher/TargetInformationBuilderTest.php
@@ -26,7 +26,7 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testProvideRouteInInformationBuilder($route, $locale, $allowedLocales)
     {
-        $request = $this->getRequestWithBrowserPreferences($route, $locale, ['_route', $route]);
+        $request = $this->getRequestWithBrowserPreferences($route, $locale, ['_route' => $route]);
         $router = $this->getRouter();
         $count = count($allowedLocales) - 1;
         if ($count >= 1) {
@@ -189,7 +189,7 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
      */
     private function getRequestWithBrowserPreferences($route = "/", $locale = '', $attributes = [])
     {
-        $request = Request::create($route);
+        $request = Request::create($route, Request::METHOD_GET, $attributes);
         $requestStack = new RequestStack();
         $request->setLocale($locale);
         foreach ($attributes as $key => $value) {

--- a/Tests/Switcher/TargetInformationBuilderTest.php
+++ b/Tests/Switcher/TargetInformationBuilderTest.php
@@ -2,25 +2,23 @@
 
 namespace Lunetics\LocaleBundle\Tests\Validator;
 
+use Lunetics\LocaleBundle\LocaleInformation\AllowedLocalesProvider;
 use Lunetics\LocaleBundle\Switcher\TargetInformationBuilder;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\RouterInterface;
 
 class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
 {
-
     public function locales()
     {
-        return array(
-            'set 1' => array('/hello-world/', 'de', array('de', 'en', 'fr')),
-            'set 2' => array('/', 'de_DE', array('de', 'en', 'fr', 'nl')),
-            'set 3' => array('/test/', 'de', array('de', 'fr_FR', 'es_ES', 'nl')),
-            'set 4' => array('/foo', 'de', array('de', 'en')),
-            'set 5' => array('/foo', 'de', array('de')),
-            'set 6' => array('/', 'de_DE', array('de_DE', 'en', 'fr', 'nl'))
-        );
+        return [
+            'set 1' => ['/hello-world/', 'de', ['de', 'en', 'fr']],
+            'set 2' => ['/', 'de_DE', ['de', 'en', 'fr', 'nl']],
+            'set 3' => ['/test/', 'de', ['de', 'fr_FR', 'es_ES', 'nl']],
+            'set 4' => ['/foo', 'de', ['de', 'en']],
+            'set 5' => ['/foo', 'de', ['de']],
+            'set 6' => ['/', 'de_DE', ['de_DE', 'en', 'fr', 'nl']],
+        ];
     }
 
     /**
@@ -28,22 +26,20 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testProvideRouteInInformationBuilder($route, $locale, $allowedLocales)
     {
-        $request = $this->getRequestWithBrowserPreferences($route, $locale);
-        $request->setLocale($locale);
-        $request->attributes->set('_route', $route);
+        $request = $this->getRequestWithBrowserPreferences($route, $locale, ['_route', $route]);
         $router = $this->getRouter();
         $count = count($allowedLocales) - 1;
         if ($count >= 1) {
             $router->expects($this->exactly($count))
-                    ->method('generate')
-                    ->with($this->equalTo('route_foo'), $this->anything())
-                    ->will($this->returnValue($route . '_generated'));
+                ->method('generate')
+                ->with($this->equalTo('route_foo'), $this->anything())
+                ->will($this->returnValue($route . '_generated'));
         } else {
             $router->expects($this->never())
-                    ->method('generate');
+                ->method('generate');
         }
 
-        $targetInformationBuilder = new TargetInformationBuilder($request, $router, $allowedLocales);
+        $targetInformationBuilder = new TargetInformationBuilder($request, $router, new AllowedLocalesProvider($allowedLocales));
         $targetInformation = $targetInformationBuilder->getTargetInformations('route_foo');
 
         $this->assertEquals($route, $targetInformation['current_route']);
@@ -54,28 +50,25 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-
     /**
      * @dataProvider locales
      */
     public function testNotProvideRouteInInformationBuilder($route, $locale, $allowedLocales)
     {
-        $request = $this->getRequestWithBrowserPreferences($route);
-        $request->setLocale($locale);
-        $request->attributes->set('_route', $route);
+        $request = $this->getRequestWithBrowserPreferences($route, $locale, ['_route' => $route]);
         $router = $this->getRouter();
         $count = count($allowedLocales) - 1;
         if ($count >= 1) {
             $router->expects($this->exactly($count))
-                    ->method('generate')
-                    ->with($this->equalTo('lunetics_locale_switcher'), $this->anything())
-                    ->will($this->returnValue($route . '_generated'));
+                ->method('generate')
+                ->with($this->equalTo('lunetics_locale_switcher'), $this->anything())
+                ->will($this->returnValue($route . '_generated'));
         } else {
             $router->expects($this->never())
-                    ->method('generate');
+                ->method('generate');
         }
 
-        $targetInformationBuilder = new TargetInformationBuilder($request, $router, $allowedLocales, false, true);
+        $targetInformationBuilder = new TargetInformationBuilder($request, $router, new AllowedLocalesProvider($allowedLocales), false, true);
         $targetInformation = $targetInformationBuilder->getTargetInformations();
 
         $this->assertEquals($route, $targetInformation['current_route']);
@@ -91,22 +84,20 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotProvideRouteInInformationBuilderNoRouter($route, $locale, $allowedLocales)
     {
-        $request = $this->getRequestWithBrowserPreferences($route);
-        $request->setLocale($locale);
-        $request->attributes->set('_route', $route);
+        $requestStack = $this->getRequestWithBrowserPreferences($route, $locale, ['_route' => $route]);
         $router = $this->getRouter();
         $count = count($allowedLocales) - 1;
         if ($count >= 1) {
             $router->expects($this->exactly($count))
-                    ->method('generate')
-                    ->with($this->equalTo($route), $this->anything())
-                    ->will($this->returnValue($route . '_generated'));
+                ->method('generate')
+                ->with($this->equalTo($route), $this->anything())
+                ->will($this->returnValue($route . '_generated'));
         } else {
             $router->expects($this->never())
-                    ->method('generate');
+                ->method('generate');
         }
 
-        $targetInformationBuilder = new TargetInformationBuilder($request, $router, $allowedLocales, false, false);
+        $targetInformationBuilder = new TargetInformationBuilder($requestStack, $router, new AllowedLocalesProvider($allowedLocales), false, false);
         $targetInformation = $targetInformationBuilder->getTargetInformations();
 
         $this->assertEquals($route, $targetInformation['current_route']);
@@ -123,11 +114,10 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testInformationBuilder($route, $locale, $allowedLocales)
     {
-        $request = $this->getRequestWithBrowserPreferences($route, $locale);
-        $request->attributes->set('_route', $route);
+        $requestStack = $this->getRequestWithBrowserPreferences($route, $locale, ['_route' => $route]);
         $router = $this->getRouter();
 
-        $targetInformationBuilder = new TargetInformationBuilder($request, $router, $allowedLocales);
+        $targetInformationBuilder = new TargetInformationBuilder($requestStack, $router, new AllowedLocalesProvider($allowedLocales));
         $targetInformation = $targetInformationBuilder->getTargetInformations();
         $this->assertEquals($locale, $targetInformation['current_locale']);
         $count = count($allowedLocales) - 1;
@@ -144,33 +134,28 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testInformationBuilderWithParams($route, $locale, $allowedLocales)
     {
-        $request = $this->getRequestWithBrowserPreferences($route);
-        $request->setLocale($locale);
-        $request->attributes->set('_route', $route);
+        $request = $this->getRequestWithBrowserPreferences($route, $locale, ['_route' => $route]);
         $router = $this->getRouter();
 
-        $targetInformationBuilder = new TargetInformationBuilder($request, $router, $allowedLocales, false, false);
+        $targetInformationBuilder = new TargetInformationBuilder($request, $router, new AllowedLocalesProvider($allowedLocales), false, false);
         if (count($allowedLocales) > 1) {
             $router->expects($this->atLeastOnce())
-                    ->method('generate')
-                    ->with($this->equalTo($route), $this->arrayHasKey('foo'));
+                ->method('generate')
+                ->with($this->equalTo($route), $this->arrayHasKey('foo'));
 
-            $targetInformationBuilder->getTargetInformations(null, array('foo' => 'bar'));
+            $targetInformationBuilder->getTargetInformations(null, ['foo' => 'bar']);
         }
     }
-
 
     /**
      * @dataProvider locales
      */
     public function testShowCurrentLocale($route, $locale, $allowedLocales)
     {
-        $request = $this->getRequestWithBrowserPreferences($route);
-        $request->setLocale($locale);
-        $request->attributes->set('_route', $route);
+        $requestStack = $this->getRequestWithBrowserPreferences($route, $locale, ['_route' => $route]);
         $router = $this->getRouter();
 
-        $targetInformationBuilder = new TargetInformationBuilder($request, $router, $allowedLocales, true);
+        $targetInformationBuilder = new TargetInformationBuilder($requestStack, $router, new AllowedLocalesProvider($allowedLocales), true);
         $targetInformation = $targetInformationBuilder->getTargetInformations();
 
         $this->assertEquals($locale, $targetInformation['current_locale']);
@@ -183,24 +168,33 @@ class TargetInformationBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerateNotCalledIfNoRoute()
     {
-        $request = $this->getRequestWithBrowserPreferences();
-        $request->attributes->set('_route', null);
+        $requestStack = $this->getRequestWithBrowserPreferences('/', '', ['_route' => null]);
         $router = $this->getRouter();
 
-        $targetInformationBuilder = new TargetInformationBuilder($request, $router, array('de', 'en', 'fr'), true, false);
+        $targetInformationBuilder = new TargetInformationBuilder($requestStack, $router, new AllowedLocalesProvider(['de', 'en', 'fr']), true, false);
         $router
             ->expects($this->never())
-            ->method('generate')
-        ;
+            ->method('generate');
 
         $targetInformationBuilder->getTargetInformations();
     }
 
-    private function getRequestWithBrowserPreferences($route = "/", $locale)
+    /**
+     * @param string $route
+     * @param string $locale
+     *
+     * @param array $attributes
+     *
+     * @return RequestStack
+     */
+    private function getRequestWithBrowserPreferences($route = "/", $locale = '', $attributes = [])
     {
         $request = Request::create($route);
         $requestStack = new RequestStack();
         $request->setLocale($locale);
+        foreach ($attributes as $key => $value) {
+            $request->attributes->set($key, $value);
+        }
         $request->headers->set('Accept-language', 'fr-FR,fr;q=0.1,en-US;q=0.6,en;q=0.4');
         $requestStack->push($request);
 

--- a/Tests/Templating/Helper/LocaleSwitchHelperTest.php
+++ b/Tests/Templating/Helper/LocaleSwitchHelperTest.php
@@ -10,6 +10,7 @@
 namespace Lunetics\LocaleBundle\Tests\Templating\Helper;
 
 use Lunetics\LocaleBundle\Templating\Helper\LocaleSwitchHelper;
+use Symfony\Component\Templating\EngineInterface;
 
 /**
  * @author Kevin Archer <ka@kevinarcher.ca>
@@ -44,6 +45,6 @@ class LocaleSwitchHelperTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockEngineInterface()
     {
-        return $this->getMock('Symfony\Component\Templating\EngineInterface');
+        return $this->createMock(EngineInterface::class);
     }
 }

--- a/Tests/Validator/LocaleAllowedValidatorTest.php
+++ b/Tests/Validator/LocaleAllowedValidatorTest.php
@@ -14,6 +14,7 @@ namespace Lunetics\LocaleBundle\Tests\Validator;
 use Lunetics\LocaleBundle\LocaleInformation\AllowedLocalesProvider;
 use Lunetics\LocaleBundle\Validator\LocaleAllowed;
 use Lunetics\LocaleBundle\Validator\LocaleAllowedValidator;
+use Symfony\Component\Validator\Constraint;
 
 /**
  * Test for the LocaleAllowedValidator
@@ -126,6 +127,6 @@ class LocaleAllowedValidatorTest extends BaseMetaValidator
     
     protected function getMockConstraint()
     {
-        return $this->getMock('Symfony\Component\Validator\Constraint');
+        return $this->createMock(Constraint::class);
     }
 }

--- a/Tests/Validator/LocaleValidatorTest.php
+++ b/Tests/Validator/LocaleValidatorTest.php
@@ -15,6 +15,7 @@ use Lunetics\LocaleBundle\Validator\Locale;
 use Lunetics\LocaleBundle\Validator\LocaleValidator;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Yaml\Parser as YamlParser;
 
 /**
@@ -134,6 +135,6 @@ class LocaleValidatorTest extends BaseMetaValidator
 
     protected function getMockConstraint()
     {
-        return $this->getMock('Symfony\Component\Validator\Constraint');
+        return $this->createMock(Constraint::class);
     }
 }


### PR DESCRIPTION
Wit this PR the twig extension shouldn't use container directly anymore, which leads to errors with service visibility in SF4.

Todo:
* [x] get tests running again