### PR TITLE
use router instead of router.default

### DIFF
--- a/Resources/config/switcher.xml
+++ b/Resources/config/switcher.xml
@@ -33,7 +33,7 @@
 
         <service id="lunetics_locale.switcher.target_information_builder" class="Lunetics\LocaleBundle\Switcher\TargetInformationBuilder">
             <argument type="service" id="request_stack" />
-            <argument type="service" id="router.default"/>
+            <argument type="service" id="router"/>
             <argument type="service" id="lunetics_locale.allowed_locales_provider"/>
             <argument>%lunetics_locale.switcher.show_current_locale%</argument>
             <argument>%lunetics_locale.switcher.use_controller%</argument>


### PR DESCRIPTION
We should not use the route.default router, as we would destroy the cmf idea of the chain-router then.